### PR TITLE
[DEVOPS-2374] -- first draft running tests in parallel

### DIFF
--- a/lib/covalence.rb
+++ b/lib/covalence.rb
@@ -1,6 +1,7 @@
 require "covalence/version"
 require "logger"
 require 'active_support/core_ext/object/blank'
+require 'etc'
 
 if %w(development test).include?(ENV['RAKE_ENV'])
   require 'byebug'
@@ -45,5 +46,5 @@ module Covalence
   LOGGER.level = Logger.const_get(LOG_LEVEL)
 
   # worker count
-  WORKER_COUNT = (ENV['WORKER_COUNT'].to_i || 3)
+  WORKER_COUNT = (ENV['WORKER_COUNT'].to_i || Etc.nprocessors)
 end

--- a/lib/covalence.rb
+++ b/lib/covalence.rb
@@ -43,4 +43,7 @@ module Covalence
   LOGGER = Logger.new(STDOUT)
   LOG_LEVEL = String(ENV['COVALENCE_LOG'] || "warn").upcase
   LOGGER.level = Logger.const_get(LOG_LEVEL)
+
+  # worker count
+  WORKER_COUNT = (ENV['WORKER_COUNT'].to_i || 3)
 end

--- a/lib/covalence/core/cli_wrappers/popen_wrapper.rb
+++ b/lib/covalence/core/cli_wrappers/popen_wrapper.rb
@@ -42,10 +42,77 @@ module Covalence
         })
       end
 
+      def logger
+        Covalence::LOGGER
+      end
+
+      def run_in_workdir(cmds, path, args, workdir,
+                         stdin_io: STDIN,
+                         stdout_io: STDOUT,
+                         stderr_io: STDERR,
+                         debug: Covalence::DEBUG_CLI,
+                         dry_run: false,
+                         ignore_exitcode: false)
+
+        logger.info "#{path} cmds: #{cmds}, path: #{path}, args: #{args}, workdir: #{workdir}"
+        # TODO: implement path prefix for the docker runs, see @tf_cmd
+        cmd_string = [*cmds]
+        # TODO: cmd escape issues with -var.
+        cmd_string += [*args] unless args.blank?
+        ## cmd_string << path unless path.blank?
+
+        run_cmd = cmd_string.join(' ')
+        print_cmd_string(run_cmd)
+        if dry_run
+          run_cmd = Covalence::DRY_RUN_CMD
+        end
+
+        if debug
+          return 0 unless HighLine.new.agree('Execute? [y/n]')
+        end
+
+        spawn_subprocess_with_workdir(ENV, run_cmd, workdir, path,{
+            stdin_io: stdin_io,
+            stdout_io: stdout_io,
+            stderr_io: stderr_io,
+            ignore_exitcode: ignore_exitcode
+        })
+      end
+
       private
       def print_cmd_string(cmd_string)
         Covalence::LOGGER.warn "---"
         Covalence::LOGGER.warn cmd_string
+      end
+
+      def spawn_subprocess_with_workdir(env, run_cmd, workdir, path,
+                           stdin_io: STDIN,
+                           stdout_io: STDOUT,
+                           stderr_io: STDERR,
+                           ignore_exitcode: false)
+
+        logger.info "#{path} run_cmd: #{run_cmd}"
+        Signal.trap("INT") {} #Disable parent process from exiting, orphaning the child fork below
+        wait_thread = nil
+        prefix=path.gsub(/^\/workspace*/,'')
+        Open3.popen3(env, "prefixout -p '#{prefix} ' -- " + run_cmd, :chdir=>workdir) do |stdin, stdout, stderr, wait_thr|
+          mappings = { stdin_io => stdin, stdout => stdout_io, stderr => stderr_io }
+          wait_thread = wait_thr
+
+          Signal.trap("INT") {
+            Process.kill("INT", wait_thr.pid)
+            Process.wait(wait_thr.pid, Process::WNOHANG)
+            exit(wait_thr.value.exitstatus)
+          } # let SIGINT drop into the child process
+
+          handle_io_streams(mappings, stdin_io)
+        end
+
+        Signal.trap("INT") { exit } #Restore parent SIGINT
+
+        return 0 if ignore_exitcode
+        exit(wait_thread.value.exitstatus) unless wait_thread.value.success?
+        return wait_thread.value.exitstatus
       end
 
       def spawn_subprocess(env, run_cmd,

--- a/lib/covalence/core/cli_wrappers/popen_wrapper.rb
+++ b/lib/covalence/core/cli_wrappers/popen_wrapper.rb
@@ -118,10 +118,12 @@ module Covalence
                        path: Dir.pwd,
                        workdir: Dir.pwd)
         logger.info "path: #{path} workdir: #{workdir} run_cmd: #{run_cmd}"
-        Signal.trap("INT") {} #Disable parent process from exiting, orphaning the child fork below
+        ## TODO better way to clean up child process if parent dies
+        Signal.trap("INT") { logger.info "Trapped Ctrl-c. Disable parent process from exiting, orphaning the child fork below" }
         wait_thread = nil
         prefix=path.gsub(/^\/workspace*/,'')
-        Open3.popen3(env, "prefixout -p '#{prefix} ' -- " + run_cmd, :chdir=>workdir) do |stdin, stdout, stderr, wait_thr|
+        whole_cmd=['prefixout', '-p', "#{prefix} ", '--'].concat(run_cmd.split)
+        Open3.popen3(env, *whole_cmd, :chdir=>workdir) do |stdin, stdout, stderr, wait_thr|
           mappings = { stdin_io => stdin, stdout => stdout_io, stderr => stderr_io }
           wait_thread = wait_thr
 

--- a/lib/covalence/core/cli_wrappers/popen_wrapper.rb
+++ b/lib/covalence/core/cli_wrappers/popen_wrapper.rb
@@ -86,7 +86,10 @@ module Covalence
                           stderr_io: STDERR,
                           ignore_exitcode: false,
                           path: nil)
-        Signal.trap("INT") {} #Disable parent process from exiting, orphaning the child fork below
+        ## TODO one thing we can try is to use
+        # Prctl.call(Prctl::PR_SET_PDEATHSIG, Signal.list['TERM'], 0, 0, 0)
+        # so when the parent dies, child will know to terminate itself.
+        Signal.trap("INT") { logger.info "Trapped Ctrl-c. Disable parent process from exiting, orphaning the child fork below which may or may not work" }
         wait_thread = nil
 
         Open3.popen3(env, run_cmd) do |stdin, stdout, stderr, wait_thr|
@@ -118,8 +121,10 @@ module Covalence
                        path: Dir.pwd,
                        workdir: Dir.pwd)
         logger.info "path: #{path} workdir: #{workdir} run_cmd: #{run_cmd}"
-        ## TODO better way to clean up child process if parent dies
-        Signal.trap("INT") { logger.info "Trapped Ctrl-c. Disable parent process from exiting, orphaning the child fork below" }
+        ## TODO one thing we can try is to use
+        # Prctl.call(Prctl::PR_SET_PDEATHSIG, Signal.list['TERM'], 0, 0, 0)
+        # so when the parent dies, child will know to terminate itself.
+        Signal.trap("INT") { logger.info "Trapped Ctrl-c. Disable parent process from exiting, orphaning the child fork below which may or may not work" }
         wait_thread = nil
         prefix=path.gsub(/^\/workspace*/,'')
         whole_cmd=['prefixout', '-p', "#{prefix} ", '--'].concat(run_cmd.split)

--- a/lib/covalence/core/cli_wrappers/terraform_cli.rb
+++ b/lib/covalence/core/cli_wrappers/terraform_cli.rb
@@ -34,24 +34,68 @@ module Covalence
     end
 
     def self.terraform_check_style(path)
-      output, status = Open3.capture2e(ENV, Covalence::TERRAFORM_CMD, "fmt", "-write=false", path)
-      return false unless status.success?
-      output = output.split("\n")
-      (output.size == 0)
-    end
-
-    def self.terraform_init(path='', args: '', ignore_exitcode: false)
-      if ENV['TF_PLUGIN_LOCAL'] == 'true'
-        cmd = [Covalence::TERRAFORM_CMD, "init", "-get=false", "-input=false", "-plugin-dir=#{Covalence::TERRAFORM_PLUGIN_CACHE}"]
-      else
-        cmd = [Covalence::TERRAFORM_CMD, "init", "-get=false", "-input=false"]
-      end
+      cmd = [Covalence::TERRAFORM_CMD, "fmt", "-check"]
 
       output = PopenWrapper.run(
+          cmd,
+          path,
+          '',
+          ignore_exitcode: false)
+      (output == 0)
+    end
+
+    def self.terraform_init(path: '', workdir: Dir.pwd, args: '', ignore_exitcode: false)
+      if ENV['TF_PLUGIN_LOCAL'] == 'true'
+        cmd = [Covalence::TERRAFORM_CMD, "init", "-get-plugins=false", "-get=false", "-input=false", "-plugin-dir=#{Covalence::TERRAFORM_PLUGIN_CACHE}"]
+      else
+        cmd = [Covalence::TERRAFORM_CMD, "init", "-get-plugins=false", "-get=false", "-input=false"]
+      end
+
+      output = PopenWrapper.run_in_workdir(
         cmd,
         path,
         args,
+        workdir,
         ignore_exitcode: ignore_exitcode)
+      (output == 0)
+    end
+
+    def self.terraform_get(path=Dir.pwd, workdir=Dir.pwd, args: '', ignore_exitcode: false)
+      cmd = [Covalence::TERRAFORM_CMD, "get", path]
+
+      output = PopenWrapper.run_in_workdir(
+          cmd,
+          path,
+          args,
+          workdir,
+          ignore_exitcode: ignore_exitcode)
+
+      (output == 0)
+    end
+
+    def self.terraform_plan(path: '', workdir: Dir.pwd, args: '', ignore_exitcode: false)
+      cmd = [Covalence::TERRAFORM_CMD, "plan"]
+
+      output = PopenWrapper.run_in_workdir(
+          cmd,
+          path,
+          args,
+          workdir,
+          ignore_exitcode: ignore_exitcode)
+
+      (output == 0)
+    end
+
+    def self.terraform_validate(path, workdir, args: '', ignore_exitcode: false)
+      cmd = [Covalence::TERRAFORM_CMD, "validate"]
+
+      output = PopenWrapper.run_in_workdir(
+          cmd,
+          path,
+          args,
+          workdir,
+          ignore_exitcode: ignore_exitcode)
+
       (output == 0)
     end
 
@@ -79,6 +123,9 @@ module Covalence
       raise "TODO: implement me"
     end
 
+    def self.logger
+      Covalence::LOGGER
+    end
 
     class << self
       private

--- a/lib/covalence/core/cli_wrappers/terraform_cli.rb
+++ b/lib/covalence/core/cli_wrappers/terraform_cli.rb
@@ -51,24 +51,24 @@ module Covalence
         cmd = [Covalence::TERRAFORM_CMD, "init", "-get-plugins=false", "-get=false", "-input=false"]
       end
 
-      output = PopenWrapper.run_in_workdir(
+      output = PopenWrapper.run(
         cmd,
         path,
         args,
-        workdir,
-        ignore_exitcode: ignore_exitcode)
+        ignore_exitcode: ignore_exitcode,
+        workdir: workdir)
       (output == 0)
     end
 
     def self.terraform_get(path=Dir.pwd, workdir=Dir.pwd, args: '', ignore_exitcode: false)
       cmd = [Covalence::TERRAFORM_CMD, "get", path]
 
-      output = PopenWrapper.run_in_workdir(
+      output = PopenWrapper.run(
           cmd,
           path,
           args,
-          workdir,
-          ignore_exitcode: ignore_exitcode)
+          ignore_exitcode: ignore_exitcode,
+          workdir: workdir)
 
       (output == 0)
     end
@@ -76,12 +76,12 @@ module Covalence
     def self.terraform_plan(path: '', workdir: Dir.pwd, args: '', ignore_exitcode: false)
       cmd = [Covalence::TERRAFORM_CMD, "plan"]
 
-      output = PopenWrapper.run_in_workdir(
+      output = PopenWrapper.run(
           cmd,
           path,
           args,
-          workdir,
-          ignore_exitcode: ignore_exitcode)
+          ignore_exitcode: ignore_exitcode,
+          workdir: workdir)
 
       (output == 0)
     end
@@ -89,12 +89,12 @@ module Covalence
     def self.terraform_validate(path, workdir, args: '', ignore_exitcode: false)
       cmd = [Covalence::TERRAFORM_CMD, "validate"]
 
-      output = PopenWrapper.run_in_workdir(
+      output = PopenWrapper.run(
           cmd,
           path,
           args,
-          workdir,
-          ignore_exitcode: ignore_exitcode)
+          ignore_exitcode: ignore_exitcode,
+          workdir: workdir)
 
       (output == 0)
     end

--- a/lib/covalence/core/entities/stack.rb
+++ b/lib/covalence/core/entities/stack.rb
@@ -41,14 +41,14 @@ module Covalence
       "#{environment_name}-#{name}"
     end
 
-    def materialize_cmd_inputs
+    def materialize_cmd_inputs(path)
       if type == "terraform"
         config = ""
         inputs.values.map(&:to_command_option).each do |input|
           config += input + "\n"
         end
-        logger.info "\nStack inputs:\n\n#{config}"
-        File.open('covalence-inputs.tfvars','w') {|f| f.write(config)}
+        logger.info "#{module_path} \nStack inputs:\n\n#{config}"
+        File.open("#{path}/covalence-inputs.tfvars",'w') {|f| f.write(config)}
       elsif type == "packer"
         config = Hash.new
         inputs.each do |name, input|

--- a/lib/covalence/core/services/packer_stack_tasks.rb
+++ b/lib/covalence/core/services/packer_stack_tasks.rb
@@ -25,7 +25,7 @@ module Covalence
         Dir.chdir(tmpdir) do
           logger.info "In #{tmpdir}:"
 
-          stack.materialize_cmd_inputs
+          stack.materialize_cmd_inputs(tmpdir)
           args = collect_args(stack.args,
                               additional_args,
                               "-var-file=covalence-inputs.json")
@@ -52,7 +52,7 @@ module Covalence
         Dir.chdir(tmpdir) do
           logger.info "In #{tmpdir}:"
 
-          stack.materialize_cmd_inputs
+          stack.materialize_cmd_inputs(tmpdir)
           args = collect_args(stack.args,
                               additional_args,
                               "-var-file=covalence-inputs.json")

--- a/lib/covalence/core/services/terraform_stack_tasks.rb
+++ b/lib/covalence/core/services/terraform_stack_tasks.rb
@@ -36,7 +36,7 @@ module Covalence
           TerraformCli.terraform_get(@path)
           TerraformCli.terraform_init
 
-          stack.materialize_cmd_inputs
+          stack.materialize_cmd_inputs(tmpdir)
 
           shell = ENV.fetch('SHELL', 'sh')
           system(shell)
@@ -83,7 +83,7 @@ module Covalence
           TerraformCli.terraform_get(@path)
           TerraformCli.terraform_init
 
-          stack.materialize_cmd_inputs
+          stack.materialize_cmd_inputs(tmpdir)
           args = collect_args("-input=false",
                               stack.args,
                               "-var-file=covalence-inputs.tfvars")
@@ -153,7 +153,7 @@ module Covalence
           TerraformCli.terraform_get(@path)
           TerraformCli.terraform_init
 
-          stack.materialize_cmd_inputs
+          stack.materialize_cmd_inputs(tmpdir)
           args = collect_args("-destroy",
                               "-input=false",
                               stack.args,
@@ -178,7 +178,7 @@ module Covalence
           TerraformCli.terraform_get(@path)
           TerraformCli.terraform_init
 
-          stack.materialize_cmd_inputs
+          stack.materialize_cmd_inputs(tmpdir)
           args = collect_args("-input=false",
                               "-auto-approve=true",
                               stack.args,
@@ -203,7 +203,7 @@ module Covalence
           TerraformCli.terraform_get(@path)
           TerraformCli.terraform_init
 
-          stack.materialize_cmd_inputs
+          stack.materialize_cmd_inputs(tmpdir)
           args = collect_args("-input=false",
                               "-auto-approve=true",
                               stack.args,

--- a/lib/covalence/environment_tasks.rb
+++ b/lib/covalence/environment_tasks.rb
@@ -156,7 +156,8 @@ module Covalence
       desc "Verify the #{stack_name} stack of the #{environment_name} environment"
       # Maybe verify_local to highlight that it skips pulling in remote state
       task generate_rake_taskname(environment_name, stack_name, "verify") do
-        tf_tasks.stack_verify
+        _tmp_dir = Dir.mktmpdir
+        tf_tasks.stack_verify(_tmp_dir)
       end
 
       desc "Shell into the #{stack_name} stack of the #{environment_name} environment"

--- a/lib/covalence/rake/rspec/envs_spec.rb
+++ b/lib/covalence/rake/rspec/envs_spec.rb
@@ -28,7 +28,7 @@ module Covalence
             exit false if !tf_tasks.stack_verify(_tmp_dir)
           when 'packer'
             packer_tasks = PackerStackTasks.new(stack)
-            ## exit false if !packer_tasks.context_validate(stack.contexts.first.to_packer_command_options)
+            exit false if !packer_tasks.context_validate(stack.contexts.first.to_packer_command_options)
           end
         end
       rescue ThreadError => e
@@ -36,86 +36,5 @@ module Covalence
     end
   end
   myworkers.map(&:join)
-
-=begin
-  environments.each do |environment|
-    environment.stacks.each do |stack|
-      EnvironmentRepository.populate_stack(stack)
-      case stack.type
-      when 'terraform'
-        tf_tasks = TerraformStackTasks.new(stack)
-      when 'packer'
-        packer_tasks = PackerStackTasks.new(stack)
-      end
-
-      path = File.expand_path(File.join(TERRAFORM, stack.module_path))
-
-      describe "Verify #{environment.name}:#{stack.name}" do
-
-        if stack.type == 'terraform'
-
-          it 'passes style check' do
-            expect {
-              expect(TerraformCli.terraform_check_style(path)).to be true
-            }.to_not raise_error
-          end
-
-          it 'passes validation' do
-            tmp_dir = Dir.mktmpdir
-            # Copy module to the workspace
-            FileUtils.copy_entry path, tmp_dir
-
-            # Copy any dependencies to the workspace
-            stack.dependencies.each do |dep|
-              dep_path = File.expand_path(File.join(Covalence::TERRAFORM, dep))
-              FileUtils.cp_r dep_path, tmp_dir
-            end
-
-            Dir.chdir(tmp_dir) do
-              expect {
-                expect(TerraformCli.terraform_get(path)).to be true
-              }.to_not raise_error
-
-              expect {
-                expect(TerraformCli.terraform_init).to be true
-              }.to_not raise_error
-
-              stack.materialize_cmd_inputs
-
-              tf_vers = Gem::Version.new(Covalence::TERRAFORM_VERSION)
-
-              if tf_vers >= Gem::Version.new('0.12.0')
-                # >= 0.12 does *not* support validating input vars
-                expect {
-                  expect(TerraformCli.terraform_validate()).to be true
-                }.to_not raise_error
-              else
-                # < 0.12 supports validating input vars
-                expect {
-                  expect(TerraformCli.terraform_validate("-input=false -var-file=covalence-inputs.tfvars")).to be true
-                }.to_not raise_error
-              end
-            end
-          end
-
-          it 'passes execution' do
-            expect {
-              expect(tf_tasks.stack_verify).to be true
-            }.to_not raise_error
-          end
-
-        elsif stack.type == 'packer'
-
-          it 'passes validation' do
-            expect {
-              expect(packer_tasks.context_validate(stack.contexts.first.to_packer_command_options)).to be true
-            }.to_not raise_error
-          end
-        end
-      end
-    end
-  end
-=end
-
 end
 

--- a/lib/covalence/rake/rspec/envs_spec.rb
+++ b/lib/covalence/rake/rspec/envs_spec.rb
@@ -5,7 +5,6 @@ module Covalence
     TEST_ENVS.include?(environ.name.to_s)
   end
 
-  POOL_SIZE = Covalence::WORKER_COUNT
   jobs = Queue.new
   # populate the job queue
   environments.each do |environment|
@@ -17,7 +16,7 @@ module Covalence
   Covalence::LOGGER.info "jobs.length: #{jobs.length}"
 
   # start the workers
-  myworkers = (POOL_SIZE).times.map do
+  myworkers = (Covalence::WORKER_COUNT).times.map do
     Thread.new do
       begin
         while stack = jobs.pop(true)

--- a/lib/covalence/rake/rspec/envs_spec.rb
+++ b/lib/covalence/rake/rspec/envs_spec.rb
@@ -7,16 +7,16 @@ module Covalence
 
   POOL_SIZE = Covalence::WORKER_COUNT
   jobs = Queue.new
-  ################ populate the job queue
+  # populate the job queue
   environments.each do |environment|
     environment.stacks.each do |stack|
       EnvironmentRepository.populate_stack(stack)
       jobs.push(stack)
     end
   end
-  Covalence::LOGGER.info "======================> jobs.length: #{jobs.length}"
+  Covalence::LOGGER.info "jobs.length: #{jobs.length}"
 
-  ############### start the workers
+  # start the workers
   myworkers = (POOL_SIZE).times.map do
     Thread.new do
       begin

--- a/lib/covalence/rake/rspec/envs_spec.rb
+++ b/lib/covalence/rake/rspec/envs_spec.rb
@@ -5,6 +5,39 @@ module Covalence
     TEST_ENVS.include?(environ.name.to_s)
   end
 
+  POOL_SIZE = Covalence::WORKER_COUNT
+  jobs = Queue.new
+  ################ populate the job queue
+  environments.each do |environment|
+    environment.stacks.each do |stack|
+      EnvironmentRepository.populate_stack(stack)
+      jobs.push(stack)
+    end
+  end
+  Covalence::LOGGER.info "======================> jobs.length: #{jobs.length}"
+
+  ############### start the workers
+  myworkers = (POOL_SIZE).times.map do
+    Thread.new do
+      begin
+        while stack = jobs.pop(true)
+          case stack.type
+          when 'terraform'
+            _tmp_dir = Dir.mktmpdir
+            tf_tasks = TerraformStackTasks.new(stack)
+            exit false if !tf_tasks.stack_verify(_tmp_dir)
+          when 'packer'
+            packer_tasks = PackerStackTasks.new(stack)
+            ## exit false if !packer_tasks.context_validate(stack.contexts.first.to_packer_command_options)
+          end
+        end
+      rescue ThreadError => e
+      end
+    end
+  end
+  myworkers.map(&:join)
+
+=begin
   environments.each do |environment|
     environment.stacks.each do |stack|
       EnvironmentRepository.populate_stack(stack)
@@ -82,4 +115,7 @@ module Covalence
       end
     end
   end
+=end
+
 end
+

--- a/spec/core/cli_wrappers/terraform_cli_spec.rb
+++ b/spec/core/cli_wrappers/terraform_cli_spec.rb
@@ -67,7 +67,7 @@ module Covalence
     it "#terraform_init" do
       expected_args = [ENV, "terraform init -get=false -input=false", anything]
       expect(PopenWrapper).to receive(:spawn_subprocess).with(*expected_args).and_return(0)
-      expect(described_class.terraform_init).to be true
+      expect(described_class.terraform_init(@tmp_dir)).to be true
     end
 
     it "#terraform_plan" do
@@ -97,7 +97,7 @@ module Covalence
     it "#terraform_validate" do
       expected_args = [ENV, "terraform validate #{@tmp_dir}", anything]
       expect(PopenWrapper).to receive(:spawn_subprocess).with(*expected_args).and_return(0)
-      expect(described_class.terraform_validate(@tmp_dir)).to be true
+      expect(described_class.terraform_validate(path=@tmp_dir, workdir=@tmp_dir)).to be true
     end
 
     it "#terraform_version" do

--- a/spec/core/entities/stack_spec.rb
+++ b/spec/core/entities/stack_spec.rb
@@ -34,7 +34,7 @@ module Covalence
 
       Dir.mktmpdir do |tmpdir|
         Dir.chdir(tmpdir) do
-          stack.materialize_cmd_inputs
+          stack.materialize_cmd_inputs(tmpdir)
         end
       end
 


### PR DESCRIPTION
This should merge after: https://github.com/WhistleLabs/dockerfile-ci/pull/44
Changes:
* add `workdir` to `terraform_get`, `terraform_init`, `terraform_validate` and `terraform_plan` since Dir.chdir() is not thread safe
* merged `terraform_check_style` to `stack_verify` for this PR. Have a separate ticket to split up plan from verify: https://whistle.atlassian.net/browse/DEVOPS-2419
* add `prefixout` to delineate each stack run
* `stack_verify` will exit out when it hit the first non-zero exit from terraform command line instead of keep running.