### PR TITLE
[DEVOPS-2526] -- removed the COVALENCE_VERSION env variable override …

### DIFF
--- a/lib/covalence/version.rb
+++ b/lib/covalence/version.rb
@@ -1,3 +1,3 @@
 module Covalence
-  VERSION = ENV["COVALENCE_VERSION"] || "0.9.7"
+  VERSION = "0.9.7"
 end


### PR DESCRIPTION
…since we defined that for a different purpose in the container build