### PR TITLE
Remove Prefixout entirely

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,6 @@ jobs:
             sudo wget -q "https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux" -O /usr/local/bin/sops
             sudo chmod +x /usr/local/bin/sops
 
-            # prefixout used in covaelnce for logging output of commands delivered
-            sudo wget -qO /tmp/prefixout_0.1.0_linux_amd64.zip "https://github.com/WhistleLabs/prefixout/releases/download/v0.1.0/prefixout_0.1.0_linux_amd64.zip" && \
-            sudo unzip -d /usr/local/bin /tmp/prefixout_0.1.0_linux_amd64.zip && \
-            sudo chmod +x /usr/local/bin/prefixout;
-
             # Install gem bundle
             gem install bundler:${BUNDLER_VERSION}
             bundle install

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ $ bin/covalence spec
 ```
 
 To run the Rspec test locally without container, you will need to install the following:
-* prefixout -- https://github.com/WhistleLabs/prefixout
 * sops -- https://github.com/mozilla/sops
 
 ### UAT

--- a/lib/covalence.rb
+++ b/lib/covalence.rb
@@ -45,7 +45,8 @@ module Covalence
   LOGGER = Logger.new(STDOUT)
   LOG_LEVEL = String(ENV['COVALENCE_LOG'] || "warn").upcase
   LOGGER.level = Logger.const_get(LOG_LEVEL)
-
+  # Disable PREFIXOUT by default unless supplied in environment variable
+  PREFIXOUT_ENABLE = (ENV['PREFIXOUT_ENABLE'] || 'false') =~ (/(true|t|yes|y|1)$/i)
   # worker count
   WORKER_COUNT = ENV.has_key?('WORKER_COUNT') ? ENV['WORKER_COUNT'].to_i : Etc.nprocessors
 end

--- a/lib/covalence.rb
+++ b/lib/covalence.rb
@@ -45,8 +45,6 @@ module Covalence
   LOGGER = Logger.new(STDOUT)
   LOG_LEVEL = String(ENV['COVALENCE_LOG'] || "warn").upcase
   LOGGER.level = Logger.const_get(LOG_LEVEL)
-  # Disable PREFIXOUT by default unless supplied in environment variable
-  PREFIXOUT_ENABLE = (ENV['PREFIXOUT_ENABLE'] || 'false') =~ (/(true|t|yes|y|1)$/i)
   # worker count
   WORKER_COUNT = ENV.has_key?('WORKER_COUNT') ? ENV['WORKER_COUNT'].to_i : Etc.nprocessors
 end

--- a/lib/covalence/core/cli_wrappers/popen_wrapper.rb
+++ b/lib/covalence/core/cli_wrappers/popen_wrapper.rb
@@ -77,8 +77,12 @@ module Covalence
         # so when the parent dies, child will know to terminate itself.
         Signal.trap("INT") { logger.info "Trapped Ctrl-c. Disable parent process from exiting, orphaning the child fork below which may or may not work" }
         wait_thread = nil
-        prefix=path.gsub(/^\/workspace*/,'')
-        whole_cmd=['prefixout', '-p', "#{prefix} ", '--'].concat(run_cmd.split)
+        if Covalence::PREFIXOUT_ENABLE
+          prefix=path.gsub(/^\/workspace*/,'')
+          whole_cmd=['prefixout', '-p', "#{prefix} ", '--'].concat(run_cmd.split)
+        else
+          whole_cmd=run_cmd
+        end
         Open3.popen3(env, *whole_cmd, :chdir=>workdir) do |stdin, stdout, stderr, wait_thr|
           mappings = { stdin_io => stdin, stdout => stdout_io, stderr => stderr_io }
           wait_thread = wait_thr

--- a/lib/covalence/core/cli_wrappers/popen_wrapper.rb
+++ b/lib/covalence/core/cli_wrappers/popen_wrapper.rb
@@ -77,13 +77,7 @@ module Covalence
         # so when the parent dies, child will know to terminate itself.
         Signal.trap("INT") { logger.info "Trapped Ctrl-c. Disable parent process from exiting, orphaning the child fork below which may or may not work" }
         wait_thread = nil
-        if Covalence::PREFIXOUT_ENABLE
-          prefix=path.gsub(/^\/workspace*/,'')
-          whole_cmd=['prefixout', '-p', "#{prefix} ", '--'].concat(run_cmd.split)
-        else
-          whole_cmd=run_cmd
-        end
-        Open3.popen3(env, *whole_cmd, :chdir=>workdir) do |stdin, stdout, stderr, wait_thr|
+        Open3.popen3(env, *run_cmd, :chdir=>workdir) do |stdin, stdout, stderr, wait_thr|
           mappings = { stdin_io => stdin, stdout => stdout_io, stderr => stderr_io }
           wait_thread = wait_thr
 


### PR DESCRIPTION
[DEVOPS-2645](https://whistle.atlassian.net/browse/DEVOPS-2645)

* Removed prefixout use entirely from covalence.
* Removed use of whole_cmd since the directory is no longer included in the command for prefixout.

**NOTE**: Additional PR will be done to [whistlelabs/dockerfile-ci](https://github.com/whistlelabs/dockerfile-ci) once this is merged. 